### PR TITLE
Allow users to specify API baseUrl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'tj.horner'
-version = '1.1'
+version = '1.2'
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/tj/horner/villagergpt/commands/ClearCommand.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/commands/ClearCommand.kt
@@ -21,7 +21,7 @@ class ClearCommand(private val plugin: VillagerGPT) : SuspendingCommandExecutor 
 
         val conversation = plugin.conversationManager.getConversation(player)
         if (conversation == null) {
-            val message = Component.text("You are not currently in a conversation. Use /ttv to start one")
+            val message = Component.text("你当前没有在对话中。使用 /ttv 开始对话。")
                 .decorate(TextDecoration.ITALIC)
 
             player.sendMessage(ChatMessageTemplate.withPluginNamePrefix(message))
@@ -30,7 +30,7 @@ class ClearCommand(private val plugin: VillagerGPT) : SuspendingCommandExecutor 
 
         conversation.reset()
 
-        val message = Component.text("Your conversation has been cleared")
+        val message = Component.text("清除了你的对话。")
             .decorate(TextDecoration.ITALIC)
         player.sendMessage(ChatMessageTemplate.withPluginNamePrefix(message))
 

--- a/src/main/kotlin/tj/horner/villagergpt/commands/EndCommand.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/commands/EndCommand.kt
@@ -21,7 +21,7 @@ class EndCommand(private val plugin: VillagerGPT) : SuspendingCommandExecutor {
 
         val conversation = plugin.conversationManager.getConversation(player)
         if (conversation == null) {
-            val message = Component.text("You are not currently in a conversation. Use /ttv to start one.")
+            val message = Component.text("你当前没有在对话中。使用 /ttv 开始对话。")
                 .decorate(TextDecoration.ITALIC)
 
             player.sendMessage(ChatMessageTemplate.withPluginNamePrefix(message))

--- a/src/main/kotlin/tj/horner/villagergpt/commands/TalkCommand.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/commands/TalkCommand.kt
@@ -24,15 +24,18 @@ class TalkCommand(private val plugin: VillagerGPT) : SuspendingCommandExecutor {
 
         val conversation = plugin.conversationManager.getConversation(player)
         if (conversation != null) {
-            val message = Component.text("You are already in a conversation with ")
+            val message = Component.text("你已经在和")
                 .append(conversation.villager.name().color(NamedTextColor.AQUA))
+                .append(Component.text("交谈了"))
                 .decorate(TextDecoration.ITALIC)
 
             player.sendMessage(ChatMessageTemplate.withPluginNamePrefix(message))
             return true
         }
 
-        val message = Component.text("Please right-click on a villager to speak with")
+        val message = Component.text("对一个村民按下[")
+            .append(Component.text("使用").color(NamedTextColor.AQUA))
+            .append(Component.text("]以开始对话"))
             .decorate(TextDecoration.ITALIC)
 
         player.sendMessage(ChatMessageTemplate.withPluginNamePrefix(message))

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerPersonality.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/VillagerPersonality.kt
@@ -1,33 +1,33 @@
 package tj.horner.villagergpt.conversation
 
 enum class VillagerPersonality {
-    ELDER {
+    ELDER { // 长者
         override fun promptDescription(): String =
-            "As an elder of the village, you have seen and done many things across the years"
+            "作为村庄里的长者，你这些年来见识过、经历过许多事情。"
     },
-    OPTIMIST {
+    OPTIMIST { // 乐观主义者
         override fun promptDescription(): String =
-            "You are an optimist that always tries to look on the bright side of things"
+            "你是一个乐观主义者，总是尝试从光明的一面看待事物。"
     },
-    GRUMPY {
+    GRUMPY { // 脾气暴躁者
         override fun promptDescription(): String =
-            "You are a grump that isn't afraid to speak his mind"
+            "你是一个脾气暴躁的人，不害怕说出自己的想法。"
     },
-    BARTERER {
+    BARTERER { // 交易者
         override fun promptDescription(): String =
-            "You are a shrewd trader that has much experience in bartering"
+            "你是一个精明的商人，在讨价还价方面有丰富的经验。"
     },
-    JESTER {
+    JESTER { // 小丑
         override fun promptDescription(): String =
-            "You enjoy telling funny jokes and are generally playful toward players"
+            "你喜欢讲有趣的笑话，并且通常对玩家很友好。"
     },
-    SERIOUS {
+    SERIOUS { // 严肃者
         override fun promptDescription(): String =
-            "You are serious and to-the-point; you do not have much patience for small talk"
+            "你很严肃，说话直截了当；对闲聊没有多少耐心。"
     },
-    EMPATH {
+    EMPATH { // 共情者
         override fun promptDescription(): String =
-            "You are a kind person and very empathetic to others' situations"
+            "你是一个善良的人，对他人的处境感同身受。"
     };
 
     abstract fun promptDescription(): String

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/OpenAIMessageProducer.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/OpenAIMessageProducer.kt
@@ -6,18 +6,19 @@ import com.aallam.openai.api.logging.LogLevel
 import com.aallam.openai.api.model.ModelId
 import com.aallam.openai.client.OpenAI
 import com.aallam.openai.client.OpenAIConfig
+import com.aallam.openai.client.OpenAIHost
 import org.bukkit.configuration.Configuration
 import tj.horner.villagergpt.conversation.VillagerConversation
 import tj.horner.villagergpt.conversation.pipeline.ConversationMessageProducer
 
 class OpenAIMessageProducer(config: Configuration) : ConversationMessageProducer {
-    private val defaultEndpoint = "https://api.openai.com/v1"
+    private val defaultEndpoint = "https://api.openai.com/v1/"
 
     private val openAI = OpenAI(
         OpenAIConfig(
             config.getString("openai-key")!!,
             LogLevel.None,
-            baseUrl = config.getString("openai-endpoint") ?: defaultEndpoint
+            host=OpenAIHost(config.getString("openai-endpoint") ?: defaultEndpoint)
         )
     )
 

--- a/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/OpenAIMessageProducer.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/conversation/pipeline/producers/OpenAIMessageProducer.kt
@@ -11,10 +11,13 @@ import tj.horner.villagergpt.conversation.VillagerConversation
 import tj.horner.villagergpt.conversation.pipeline.ConversationMessageProducer
 
 class OpenAIMessageProducer(config: Configuration) : ConversationMessageProducer {
+    private val defaultEndpoint = "https://api.openai.com/v1"
+
     private val openAI = OpenAI(
         OpenAIConfig(
             config.getString("openai-key")!!,
-            LogLevel.None
+            LogLevel.None,
+            baseUrl = config.getString("openai-endpoint") ?: defaultEndpoint
         )
     )
 

--- a/src/main/kotlin/tj/horner/villagergpt/handlers/ConversationEventsHandler.kt
+++ b/src/main/kotlin/tj/horner/villagergpt/handlers/ConversationEventsHandler.kt
@@ -24,9 +24,9 @@ import tj.horner.villagergpt.events.VillagerConversationStartEvent
 class ConversationEventsHandler(private val plugin: VillagerGPT) : Listener {
     @EventHandler
     fun onConversationStart(evt: VillagerConversationStartEvent) {
-        val message = Component.text("You are now in a conversation with ")
+        val message = Component.text("你正在与")
             .append(evt.conversation.villager.name().color(NamedTextColor.AQUA))
-            .append(Component.text(". Send a chat message to get started and use /ttvend to end it"))
+            .append(Component.text("交谈。发送聊天信息以开始对话，使用 /ttvend 以结束对话。"))
             .decorate(TextDecoration.ITALIC)
 
         evt.conversation.player.sendMessage(ChatMessageTemplate.withPluginNamePrefix(message))
@@ -39,9 +39,9 @@ class ConversationEventsHandler(private val plugin: VillagerGPT) : Listener {
 
     @EventHandler
     fun onConversationEnd(evt: VillagerConversationEndEvent) {
-        val message = Component.text("Your conversation with ")
+        val message = Component.text("与")
             .append(evt.villager.name().color(NamedTextColor.AQUA))
-            .append(Component.text(" has ended"))
+            .append(Component.text("的对话结束。"))
             .decorate(TextDecoration.ITALIC)
 
         evt.player.sendMessage(ChatMessageTemplate.withPluginNamePrefix(message))
@@ -60,8 +60,9 @@ class ConversationEventsHandler(private val plugin: VillagerGPT) : Listener {
         // Villager is in a conversation with another player
         val existingConversation = plugin.conversationManager.getConversation(villager)
         if (existingConversation != null && existingConversation.player.uniqueId != evt.player.uniqueId) {
-            val message = Component.text("This villager is in a conversation with ")
+            val message = Component.text("这个村民正在和[")
                 .append(existingConversation.player.displayName())
+                .append(Component.text("]交谈。请稍后再试。"))
                 .decorate(TextDecoration.ITALIC)
 
             evt.player.sendMessage(ChatMessageTemplate.withPluginNamePrefix(message))
@@ -75,7 +76,7 @@ class ConversationEventsHandler(private val plugin: VillagerGPT) : Listener {
         evt.isCancelled = true
 
         if (villager.profession == Villager.Profession.NONE) {
-            val message = Component.text("You can only speak to villagers with a profession")
+            val message = Component.text("这个村民没有职业，无法与之交谈。")
                 .decorate(TextDecoration.ITALIC)
 
             evt.player.sendMessage(ChatMessageTemplate.withPluginNamePrefix(message))
@@ -92,9 +93,9 @@ class ConversationEventsHandler(private val plugin: VillagerGPT) : Listener {
         evt.isCancelled = true
 
         if (conversation.pendingResponse) {
-            val message = Component.text("Please wait for ")
+            val message = Component.text("请耐心等待")
                 .append(conversation.villager.name().color(NamedTextColor.AQUA))
-                .append(Component.text(" to respond"))
+                .append(Component.text("的回复。"))
                 .decorate(TextDecoration.ITALIC)
 
             evt.player.sendMessage(ChatMessageTemplate.withPluginNamePrefix(message))
@@ -119,9 +120,9 @@ class ConversationEventsHandler(private val plugin: VillagerGPT) : Listener {
                 }
             }
         } catch(e: Exception) {
-            val message = Component.text("Something went wrong while getting ")
+            val message = Component.text("在获取")
                 .append(villager.name().color(NamedTextColor.AQUA))
-                .append(Component.text("'s response. Please try again"))
+                .append(Component.text("的回复时发生了错误，请稍后再试。"))
                 .decorate(TextDecoration.ITALIC)
 
             evt.player.sendMessage(ChatMessageTemplate.withPluginNamePrefix(message))

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,6 +5,10 @@ openai-key: ""
 # Switch this to "gpt-4" if you do.
 openai-model: "gpt-3.5-turbo"
 
+# If you wish to use an OpenAI-compatible service other than the official OpenAI API,
+# modify this. Otherwise don't touch it.
+openai-endpoint: "https://api.openai.com/v1"
+
 # Log conversation messages to server console, useful for catching abuse
 log-conversations: true
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,8 +6,8 @@ openai-key: ""
 openai-model: "gpt-3.5-turbo"
 
 # If you wish to use an OpenAI-compatible service other than the official OpenAI API,
-# modify this. Otherwise don't touch it.
-openai-endpoint: "https://api.openai.com/v1"
+# modify this. Otherwise don't touch it. This URL should always end with '/'
+openai-endpoint: "https://api.openai.com/v1/"
 
 # Log conversation messages to server console, useful for catching abuse
 log-conversations: true


### PR DESCRIPTION
This PR adds config field for `baseUrl` (presented as `openai-endpoint` in config.yml), which is essential for e.g. Chinese servers which cannot gain access to OpenAI API or users who wish to use AI services other than OpenAI.